### PR TITLE
Improvement: update image to release.2022 02 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM minio/minio:RELEASE.2020-07-24T22-43-05Z
-RUN apk add --no-cache bash
+FROM busybox as downloader
+RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh && \
+    chmod +x wait-for-it.sh
+
+FROM minio/minio:RELEASE.2022-02-18T01-50-10Z
 COPY --from=minio/mc /usr/bin/mc /usr/local/bin/mc
-COPY --from=jwilder/dockerize /usr/local/bin/dockerize /usr/local/bin/dockerize
+COPY --from=downloader /wait-for-it.sh /usr/local/bin/wait-for-it
 COPY entrypoint.sh /entrypoint
 ENTRYPOINT ["/entrypoint"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for
     chmod +x wait-for-it.sh
 
 FROM minio/minio:RELEASE.2022-02-18T01-50-10Z
+RUN microdnf install nc
 COPY --from=minio/mc /usr/bin/mc /usr/local/bin/mc
 COPY --from=downloader /wait-for-it.sh /usr/local/bin/wait-for-it
 COPY entrypoint.sh /entrypoint
+
+VOLUME ["/data"]
+
 ENTRYPOINT ["/entrypoint"]
 CMD []

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 ## Minio Development
 
-A MinIO image suited for development purposes.
+A MinIO based image which allows to configure a `default` bucket and its policy when spinning a new minio server. Useful for  development purposes.
 
 ## What is MinIO?
 
@@ -10,12 +10,14 @@ Its a 100% opensource s3 server implementation. You can see more information her
 
 To provide an image suited for development which means:
 
- * Create an default bucket to work with;
- * Configure bucket default permission through environment variables.
+* Create an default bucket to work with;
+* Configure bucket default permission through environment variables.
 
-By default, you cannot create a default/initial bucket during startup (https://github.com/minio/minio/issues/4769). Instead, you need to create a 2nd service on docker-compose or at least use a `docker exec` to configure the first bucket and its permission.
+By default, you cannot create a default/initial bucket during startup (https://github.com/minio/minio/issues/4769). Instead, you need to create a 2nd service on docker-compose, an init container on kubernetes or at least use a `docker exec/kubectl exec` to configure the first bucket and its permission.
 
-With this project, you just need to provide `MINIO_INITIAL_BUCKET` and `MINIO_INITIAL_BUCKET_PERMISSION` that will be used by the entrypoint to create the default bucket and set its permissions. In fact if dont provide those environment variables, the bucket `default` with permission `none`(private) will be created anyway.
+With this project, you just need to provide `MINIO_INITIAL_BUCKET` and `MINIO_INITIAL_BUCKET_PERMISSION` that will be used by the entrypoint to create the default bucket and set its permissions. 
+
+In fact if you dont provide those environment variables, the bucket `default` with permission `none`(private) will be created anyway (More information in the #Configurations topic).
 
 ## Using Volumes
 
@@ -23,10 +25,20 @@ By default, the entrypoint is hardcoded to use `/data` as the exported dir; so y
 
 ## How to start
 
-Be sure to have Docker and Docker-compose installed. After that, just download `docker-compose.yaml` available on the project and spin up the server using `docker-compose up -d` command.
+Be sure to have Docker and Docker-compose installed. After that, just download `docker-compose.yaml` available on the project and spin up the server using the `docker-compose up -d` command.
+
+## Configurations
+
+The following environment variables are available in addition for those used by min.io project:
+
+| Environment Variable            | Description                                                                                                | Default Value            |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------ |
+| MINIO_INITIAL_BUCKET            | The name of the bucket that will be created.                                                               | "default"                |
+| MINIO_INITIAL_BUCKET_PERMISSION | Permission configuration as described in: https://docs.min.io/docs/minio-client-complete-guide.html#policy | "none": a private bucket |
+
 
 Author
+
 ------
 
 Author: Gabriel Abdalla Cavalcante Silva (gabriel.cavalcante88@gmail.com)
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,8 @@ services:
     image: gcavalcante8808/minio-dev:latest
     build: .
     environment:
-      MINIO_ACCESS_KEY: minio
-      MINIO_SECRET_KEY: minio123
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
       MINIO_INITIAL_BUCKET: default
       MINIO_INITIAL_BUCKET_PERMISSION: none
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -em
 
 configure_initial_bucket () {
     wait-for-it -t 30 localhost:9000
-    mc config host add default http://localhost:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY}
+    mc config host add default http://localhost:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
     mc mb --ignore-existing default/"${MINIO_INITIAL_BUCKET:-default}"
     mc policy set "${MINIO_INITIAL_BUCKET_PERMISSION:-none}" default/"${MINIO_INITIAL_BUCKET:-default}"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,14 +3,14 @@
 set -em
 
 configure_initial_bucket () {
-    dockerize -wait tcp://localhost:9000 -timeout 30s
+    wait-for-it -t 30 localhost:9000
     mc config host add default http://localhost:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY}
     mc mb --ignore-existing default/"${MINIO_INITIAL_BUCKET:-default}"
     mc policy set "${MINIO_INITIAL_BUCKET_PERMISSION:-none}" default/"${MINIO_INITIAL_BUCKET:-default}"
 }
 
 start_minio_server_in_background () {
-    /usr/bin/minio server /data &
+    minio server /data &
 }
 
 return_minio_server_to_foreground () {


### PR DESCRIPTION
## Scenario

After several months, it's time to update this image to match the latest minio image in this moment (RELEASE.2022-02-18T01-50-10Z). 

## What has been done

As the upstream replace the alpine container with an redhat ubi version, some big changes has been done:

 * [x] Replaced dockerize with wait-for-it script: as the original dockerize image was using alpine and had a dependency with muslibc, it stopped to work with the ubi image used by the upstream. Additionally, removing dockerize is a plus considering that is one less amd64 dependency as the `wait-for-it` script is pure bash;
  * [x] Updated the credential environment variables on docker-compose.yaml: replaced  `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY`as it were deprecated with `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`.
  * [x] Updated README.MD.