### PR TITLE
Improvement/add console ports to docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,11 @@ services:
   minio:
     image: gcavalcante8808/minio-dev:latest
     build: .
+    ports:
+      - 9000:9000
+      - 8999:8999
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
       MINIO_INITIAL_BUCKET: default
       MINIO_INITIAL_BUCKET_PERMISSION: none
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ configure_initial_bucket () {
 }
 
 start_minio_server_in_background () {
-    minio server /data &
+    minio server --console-address ":8999" /data &
 }
 
 return_minio_server_to_foreground () {


### PR DESCRIPTION
## Scenario

This PR set a static port configuration for console and expose it by default using docker-compose.